### PR TITLE
Fix: correct urls to ones which are currently available. 

### DIFF
--- a/src/plugins/geoservices/osm/qgeotilefetcherosm.cpp
+++ b/src/plugins/geoservices/osm/qgeotilefetcherosm.cpp
@@ -59,17 +59,17 @@ QGeoTiledMapReply *QGeoTileFetcherOsm::getTileImage(const QGeoTileSpec &spec)
     switch (spec.mapId()) {
         case 1:
             // opensteetmap.org street map
-            request.setUrl(QUrl(QStringLiteral("http://otile1.mqcdn.com/tiles/1.0.0/map/") +
+            request.setUrl(QUrl(QStringLiteral("https://tile.openstreetmap.org/") +
                                 QString::number(spec.zoom()) + QLatin1Char('/') +
                                 QString::number(spec.x()) + QLatin1Char('/') +
                                 QString::number(spec.y()) + QStringLiteral(".png")));
             break;
         case 2:
             // opensteetmap.org satellite map
-            request.setUrl(QUrl(QStringLiteral("http://otile1.mqcdn.com/tiles/1.0.0/sat/") +
+            request.setUrl(QUrl(QStringLiteral("https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/") +
                                 QString::number(spec.zoom()) + QLatin1Char('/') +
                                 QString::number(spec.x()) + QLatin1Char('/') +
-                                QString::number(spec.y()) + QStringLiteral(".png")));
+                                QString::number(spec.y()) ));
             break;
         default:
             qWarning("Unknown map id %d\n", spec.mapId());

--- a/src/plugins/geoservices/osm/qgeotilefetcherosm.cpp
+++ b/src/plugins/geoservices/osm/qgeotilefetcherosm.cpp
@@ -65,11 +65,11 @@ QGeoTiledMapReply *QGeoTileFetcherOsm::getTileImage(const QGeoTileSpec &spec)
                                 QString::number(spec.y()) + QStringLiteral(".png")));
             break;
         case 2:
-            // opensteetmap.org satellite map
-            request.setUrl(QUrl(QStringLiteral("https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/") +
+            // opentopomap.org topographical 
+            request.setUrl(QUrl(QStringLiteral("https://c.tile.opentopomap.org/") +
                                 QString::number(spec.zoom()) + QLatin1Char('/') +
                                 QString::number(spec.x()) + QLatin1Char('/') +
-                                QString::number(spec.y()) ));
+                                QString::number(spec.y()) + QStringLiteral(".png")));
             break;
         default:
             qWarning("Unknown map id %d\n", spec.mapId());


### PR DESCRIPTION
I'm not sure why the newer geoservices plugins aren't in use? The 5.8 branch, for instance, is all LGPLv2. Eg. https://github.com/qt/qtlocation/blob/5.8/src/plugins/geoservices/osm/qgeotilefetcherosm.cpp This being the new 'cardinal approach' ...

This fix is not really an answer because hard coding tile servers  was a 'bad idea (tm)'. BUT, it would at least make the QML maps work, afaik.